### PR TITLE
Remove statistics graphs from landing page

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,6 +15,8 @@
 		<p>Powered by <a href="https://vertexlab.io">Vertex</a></p>
 		<p class="separator">•</p>
 		<p>Designed by <a href="/npub1t3gd5yefglarhar4n6uh34uymvft4tgu8edk5465zzhtv4rrnd9sg7upxq">Vlad</a></p>
+		<p class="separator">•</p>
+		<p><a href="/stats">Statistics</a></p>
 	</div>
 
 	<div class="theme-container">

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -3,28 +3,6 @@ import { error } from '@sveltejs/kit';
 import { query, dvm } from '$lib/nostr.js';
 import { HEXKEY_REGEXP, NPUB_REGEXP, NIP05_REGEXP } from '$lib/string.js';
 import { getPubkeys, fetchMinimalProfiles } from '$lib/profile';
-import { newDataset, formatDate } from '$lib/charts';
-import { stats } from '$lib/stats.server';
-
-export async function load({ params }) {
-  const lastStats = stats.length > 10 ? stats.slice(-10) : stats;
-  const users = [ newDataset("total"), newDataset("active"), newDataset("posters") ];
-  const events = [ newDataset("profiles"), newDataset("posts"), newDataset("follows") ];
-
-  for (const stat of lastStats) {
-    const date = formatDate(stat.date);
-
-    users[0].points.push({x: date, y: stat["total_pubkeys"] || 0 });
-    users[1].points.push({x: date, y: stat["active_pubkeys"] || 0 });
-    users[2].points.push({x: date, y: stat["creator_pubkeys"] || 0 });
-
-    events[0].points.push({x: date, y: stat["kind:0"] || 0 });
-    events[1].points.push({x: date, y: stat["kind:1"] || 0 });
-    events[2].points.push({x: date, y: stat["kind:3"] || 0 });
-  }
-
-  return {users, events}
-}
 
 /**
  * Parse and validate `q` and `limit` from URLSearchParams.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,8 @@
 <script>
   import Logo from "$lib/components/Logo.svelte";
   import SearchBox from "$lib/components/SearchBox.svelte";
-  import StatsCard from "$lib/components/StatsCard.svelte";
   import { onMount } from "svelte";
 
-  let { data } = $props();
   let searchBoxRef;
 
   onMount( () => { searchBoxRef.focus() })
@@ -22,15 +20,6 @@
       <SearchBox bind:this={searchBoxRef}/>
     </div>
   </header>
-
-  <div class="stats-grid">
-    <StatsCard datasets={data.users} title="Users"/>
-    <StatsCard datasets={data.events} title="Events"/>
-  </div>
-
-  <a href="/stats" class="stats-link">
-    <p>View more statistics</p>
-  </a>
 </div>
 
 <style>
@@ -46,18 +35,5 @@
   .search-container {
     max-width: 600px;
     margin: 0 auto;
-  }
-
-  .stats-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    justify-content: center;
-  }
-
-  .stats-link {
-    font-size: 0.8rem;
-		color: var(--secondary-text);
-    text-align: center;
   }
 </style>


### PR DESCRIPTION
Remove the statistics graphs from the landing page so it focuses purely on profile search. The stats page at `/stats` is unchanged and still accessible via a new link in the footer.

- Removed `StatsCard` components and server-side stats data fetching from `+page.svelte` and `+page.server.js`
- Added a "Statistics" link to the footer in `+layout.svelte`, next to the existing Vertex and Vlad credits

Closes #3
